### PR TITLE
Add authentication backend

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,27 @@
+[run]
+omit =
+    **/tests/*
+    .venv/*
+    conftest.py
+    *__init__*
+    setup.py
+
+[report]
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+    pass
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
+
+ignore_errors = True

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [5.1.0](https://pypi.org/project/directory-sso-api-client/5.1.0/) (2019-07-14)
+[Full Changelog](https://github.com/uktrade/directory-sso-api-client/pull/37/files)
+
+### Implemented enhancements
+
+- Added authentication backend
+
 ## [5.0.1](https://pypi.org/project/directory-sso-api-client/5.0.1/) (2019-07-04)
 [Full Changelog](https://github.com/uktrade/directory-sso-api-client/pull/36/files)
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,22 @@ Once that is done the API client can be used:
 from directory_sso_api_client.client import sso_api_client
 ```
 
+## Authentication backend
+
+Add the following to your settings
+
+```
+AUTHENTICATION_BACKENDS = ['directory_sso_api_client.backends.RemoveSSOBackend']
+
+MIDDLEWARE_CLASSES = [
+    ...
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.contrib.auth.middleware.RemoteUserMiddleware',
+    ...
+```
+
+That will result in the user being authenticate via their sso session cookie and then attached to `request.user`.
+
 ## Development
 
 ```shell

--- a/directory_sso_api_client/backends.py
+++ b/directory_sso_api_client/backends.py
@@ -1,0 +1,40 @@
+import json
+import logging
+
+from requests.exceptions import RequestException
+
+from django.conf import settings
+
+from directory_sso_api_client import models, sso_api_client
+
+
+logger = logging.getLogger(__name__)
+
+
+class SSOUserBackend:
+    MESSAGE_INVALID_JSON = (
+        'SSO did not return JSON. A 502 may have occurred so SSO nginx '
+        'redirected to http://sorry.great.gov.uk (see ED-2114)'
+    )
+    MESSAGE_SSO_UNREACHABLE = 'Unable to reach SSO'
+
+    def authenticate(self, request):
+        session_id = request.COOKIES.get(settings.SSO_SESSION_COOKIE)
+        if session_id:
+            try:
+                return self.get_user(session_id)
+            except RequestException:
+                logger.error(self.MESSAGE_SSO_UNREACHABLE, exc_info=True)
+            except json.JSONDecodeError:
+                raise ValueError(self.MESSAGE_INVALID_JSON)
+
+    def get_user(self, session_id):
+        response = sso_api_client.user.get_session_user(session_id)
+        response.raise_for_status()
+        parsed = response.json()
+        return models.SSOUser(
+            pk=parsed['id'],
+            email=parsed['email'],
+            session_id=session_id,
+            hashed_uuid=parsed['hashed_uuid']
+        )

--- a/directory_sso_api_client/backends.py
+++ b/directory_sso_api_client/backends.py
@@ -16,7 +16,7 @@ class SSOUserBackend:
         'SSO did not return JSON. A 502 may have occurred so SSO nginx '
         'redirected to http://sorry.great.gov.uk (see ED-2114)'
     )
-    MESSAGE_SSO_UNREACHABLE = 'Unable to reach SSO'
+    MESSAGE_NOT_SUCCESSFUL = 'SSO did not return a 200 response'
 
     def authenticate(self, request):
         session_id = request.COOKIES.get(settings.SSO_SESSION_COOKIE)
@@ -24,7 +24,7 @@ class SSOUserBackend:
             try:
                 return self.get_user(session_id)
             except RequestException:
-                logger.error(self.MESSAGE_SSO_UNREACHABLE, exc_info=True)
+                logger.error(self.MESSAGE_NOT_SUCCESSFUL, exc_info=True)
             except json.JSONDecodeError:
                 raise ValueError(self.MESSAGE_INVALID_JSON)
 

--- a/directory_sso_api_client/middleware.py
+++ b/directory_sso_api_client/middleware.py
@@ -1,5 +1,6 @@
 from django.utils.deprecation import MiddlewareMixin
 from django.contrib import auth
+from django.contrib.auth.models import AnonymousUser
 
 
 class AuthenticationMiddleware(MiddlewareMixin):
@@ -10,4 +11,4 @@ class AuthenticationMiddleware(MiddlewareMixin):
             request.user = user
             auth.login(request, user)
         else:
-            request.user = None
+            request.user = AnonymousUser()

--- a/directory_sso_api_client/middleware.py
+++ b/directory_sso_api_client/middleware.py
@@ -1,0 +1,13 @@
+from django.utils.deprecation import MiddlewareMixin
+from django.contrib import auth
+
+
+class AuthenticationMiddleware(MiddlewareMixin):
+
+    def process_request(self, request):
+        user = auth.authenticate(request)
+        if user:
+            request.user = user
+            auth.login(request, user)
+        else:
+            request.user = None

--- a/directory_sso_api_client/models.py
+++ b/directory_sso_api_client/models.py
@@ -1,0 +1,30 @@
+from django.contrib.auth.models import AbstractUser
+
+from django.db import models
+
+from directory_sso_api_client import sso_api_client
+
+
+class SSOUser(AbstractUser):
+    session_id = models.TextField()
+    hashed_uuid = models.CharField(max_length=200)
+
+    def check_password(self, raw_password):
+        response = sso_api_client.usercheck_password(
+            session_id=self.session_id, password=raw_password
+        )
+        return response.ok
+
+    def get_username(self):
+        return self.email
+
+    def set_password(self):
+        raise NotImplementedError
+
+    def set_unusable_password(self):
+        raise NotImplementedError
+
+    def save(self, *args, **kwargs):
+        # django.contrib.auth.login fires a signal that results in django
+        # trying to save last_logged_in, so don't raise NotImplementedError
+        pass

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='directory_sso_api_client',
-    version='5.0.1',
+    version='5.1.0',
     url='https://github.com/uktrade/directory-sso-api-client',
     license='MIT',
     author='Department for International Trade',
@@ -19,7 +19,7 @@ setup(
         'test': [
             'django>=1.11.22,<2.0a1',
             'requests>=2.18.4,<3.0.0',
-            'pytest==3.0.2',
+            'pytest==3.6.0',
             'pytest-cov==2.3.1',
             'flake8==3.0.4',
             'requests_mock==1.1.0',
@@ -27,6 +27,8 @@ setup(
             'twine>=1.11.0,<2.0.0',
             'wheel>=0.31.0,<1.0.0',
             'setuptools>=38.6.0,<39.0.0',
+            'pytest-django>=3.2.1,<4.0.0',
+            'pytest-sugar>=0.9.1,<1.0.0',
         ]
     },
     classifiers=[

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,26 @@
 def pytest_configure():
     from django.conf import settings
     settings.configure(
+        INSTALLED_APPS=[
+            'django.contrib.auth',
+            'django.contrib.contenttypes',
+            'django.contrib.sessions',
+            'directory_sso_api_client',
+        ],
         URLS_EXCLUDED_FROM_SIGNATURE_CHECK=[],
         DIRECTORY_SSO_API_CLIENT_BASE_URL='https://sso.com',
         DIRECTORY_SSO_API_CLIENT_API_KEY='test-api-key',
         DIRECTORY_SSO_API_CLIENT_SENDER_ID='test-sender',
         DIRECTORY_SSO_API_CLIENT_DEFAULT_TIMEOUT=5,
+        AUTHENTICATION_BACKENDS=[
+            'directory_sso_api_client.backends.SSOUserBackend',
+        ],
+        AUTH_USER_MODEL='directory_sso_api_client.SSOUser',
+        MIDDLEWARE_CLASSES=[
+            'django.contrib.sessions.middleware.SessionMiddleware',
+            'directory_sso_api_client.middleware.AuthenticationMiddleware',
+        ],
+        SSO_SESSION_COOKIE='sso_session_cookie',
+        SESSION_ENGINE='django.contrib.sessions.backends.signed_cookies',
+        ROOT_URLCONF='tests.urls',
     )

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -78,7 +78,7 @@ def test_remote_sso_backend_timeout(sso_request, caplog, excpetion_class):
 
     log = caplog.records[0]
     assert log.levelname == 'ERROR'
-    assert log.msg == backends.SSOUserBackend.MESSAGE_SSO_UNREACHABLE
+    assert log.msg == backends.SSOUserBackend.MESSAGE_NOT_SUCCESSFUL
 
 
 def test_end_to_end(client, settings):

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,0 +1,97 @@
+from unittest import mock
+
+import pytest
+import requests
+import requests_mock
+
+from django.contrib.auth import authenticate
+
+from directory_sso_api_client import backends, sso_api_client
+
+
+@pytest.fixture
+def sso_request(rf, settings, client):
+    request = rf.get('/')
+    request.COOKIES[settings.SSO_SESSION_COOKIE] = '123'
+    request.session = client.session
+    return request
+
+
+@mock.patch.object(sso_api_client.user, 'get_session_user')
+def test_remote_sso_backend_no_cookie(mock_get_session_user, rf):
+    request = rf.get('/')
+
+    assert authenticate(request) is None
+    assert mock_get_session_user.call_count == 0
+
+
+@mock.patch.object(
+    sso_api_client.user, 'get_session_user',
+    wraps=sso_api_client.user.get_session_user
+)
+def test_remote_sso_backend_api_response_ok(
+    mock_get_session_user, sso_request
+):
+    with requests_mock.mock() as m:
+        m.get(
+            'https://sso.com/api/v1/session-user/',
+            json={'id': 1, 'email': 'jim@example.com', 'hashed_uuid': 'thing'}
+        )
+        user = authenticate(sso_request)
+        assert user.pk == 1
+        assert user.email == 'jim@example.com'
+        assert user.hashed_uuid == 'thing'
+
+    assert mock_get_session_user.call_count == 1
+    assert mock_get_session_user.call_args == mock.call('123')
+
+
+def test_remote_sso_backend_bad_response(sso_request):
+    with requests_mock.mock() as m:
+        m.get(
+            'https://sso.com/api/v1/session-user/',
+            status_code=400,
+        )
+        assert authenticate(sso_request) is None
+
+
+def test_remote_sso_backend_not_josn_response(sso_request):
+    with requests_mock.mock() as m:
+        m.get(
+            'https://sso.com/api/v1/session-user/',
+            text='<html></html>'
+        )
+        with pytest.raises(ValueError):
+            assert authenticate(sso_request) is None
+
+
+@pytest.mark.parametrize(
+    'excpetion_class', requests.exceptions.RequestException.__subclasses__()
+)
+def test_remote_sso_backend_timeout(sso_request, caplog, excpetion_class):
+    with requests_mock.mock() as m:
+        m.get(
+            'https://sso.com/api/v1/session-user/',
+            exc=excpetion_class
+        )
+        assert authenticate(sso_request) is None
+
+    log = caplog.records[0]
+    assert log.levelname == 'ERROR'
+    assert log.msg == backends.SSOUserBackend.MESSAGE_SSO_UNREACHABLE
+
+
+def test_end_to_end(client, settings):
+    client.cookies[settings.SSO_SESSION_COOKIE] = '123'
+
+    with requests_mock.mock() as m:
+        m.get(
+            'https://sso.com/api/v1/session-user/',
+            json={'id': 1, 'email': 'jim@example.com', 'hashed_uuid': 'thing'}
+        )
+        response = client.get('/')
+
+    request = response.wsgi_request
+    assert request.user.pk == 1
+    assert request.user.email == 'jim@example.com'
+    assert request.user.hashed_uuid == 'thing'

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,17 @@
+import requests_mock
+
+
+def test_end_to_end(client, settings):
+    client.cookies[settings.SSO_SESSION_COOKIE] = '123'
+
+    with requests_mock.mock() as m:
+        m.get(
+            'https://sso.com/api/v1/session-user/',
+            json={'id': 1, 'email': 'jim@example.com', 'hashed_uuid': 'thing'}
+        )
+        response = client.get('/')
+
+    request = response.wsgi_request
+    assert request.user.pk == 1
+    assert request.user.email == 'jim@example.com'
+    assert request.user.hashed_uuid == 'thing'

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,7 +1,7 @@
 import requests_mock
 
 
-def test_end_to_end(client, settings):
+def test_authenticcated(client, settings):
     client.cookies[settings.SSO_SESSION_COOKIE] = '123'
 
     with requests_mock.mock() as m:
@@ -12,6 +12,18 @@ def test_end_to_end(client, settings):
         response = client.get('/')
 
     request = response.wsgi_request
+    assert request.user.is_authenticated() is True
     assert request.user.pk == 1
     assert request.user.email == 'jim@example.com'
     assert request.user.hashed_uuid == 'thing'
+
+
+def test_not_authenticcated(client, settings):
+    client.cookies[settings.SSO_SESSION_COOKIE] = '123'
+
+    with requests_mock.mock() as m:
+        m.get('https://sso.com/api/v1/session-user/', status_code=404)
+        response = client.get('/')
+
+    request = response.wsgi_request
+    assert request.user.is_authenticated() is False

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,0 +1,18 @@
+from django.conf.urls import url
+from django.views import View
+from django.http import HttpResponse
+
+
+class TestView(View):
+    http_method_names = ['get']
+
+    def get(self, request):
+        return HttpResponse()
+
+
+urlpatterns = [
+    url(
+        r'^$',
+        TestView.as_view(),
+    ),
+]


### PR DESCRIPTION
Uses the more standard django way of handling user authentication: [authentication backends](https://docs.djangoproject.com/en/2.2/topics/auth/customizing). This means we can use django docs as our docs.

Another nice thing about this approach is devs can interact with the `request.user` in a more natural way:

```
request.user  # previously we did request.sso_user
request.user.check_password('foo')
```

This also open up a nice route for standard django permission checks too

```
request.user.has_perm(...)
```

maybe even  the following if there is an appetite:

```
SSOUser.objects.create(....)  #  wraps around `sso_api_client.user.create_user
SSOUser.objects.get(...)  # wraps around sso_apI_client.user.get_session_user or get_oauth2_user_profile
```