### PR TITLE
Remove changelog check from PR template

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
             . .venv/bin/activate
             pip install --upgrade pip
             make test_requirements
-            make test
+            make test -- --codecov-token=${CODECOV_TOKEN}
 
   flake8:
     docker:

--- a/makefile
+++ b/makefile
@@ -11,15 +11,18 @@ flake8:
 	flake8 . --exclude=.venv --max-line-length=120
 
 pytest:
-	pytest . --cov=. $(pytest_args) --capture=no -vv
+	pytest . --capture=no -vv
 
-CODECOV := \
-	if [ "$$CODECOV_REPO_TOKEN" != "" ]; then \
-	   codecov --token=$$CODECOV_REPO_TOKEN ;\
-	fi
+pytest_codecov:
+	pytest \
+		--junitxml=test-reports/junit.xml \
+		--cov-config=.coveragerc \
+		--cov-report=term \
+		--cov=. \
+		--codecov \
+		$(ARGUMENTS)
 
-test: flake8 pytest
-	$(CODECOV)
+test: flake8 pytest_codecov
 
 publish:
 	rm -rf build dist; \

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,7 +1,7 @@
 To do (delete all that do not apply):
 
  - [ ] Change has a jira ticket that has the correct status.
- - [ ] Changelog entry added.
+ - [ ] A clear description/pull request message has been added.
  - [ ] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
  - [ ] (if updating requirements) Requirements have been compiled.
  - [ ] (if adding env vars) Added any new environment variable to vault.

--- a/setup.py
+++ b/setup.py
@@ -16,15 +16,15 @@ setup(
     ],
     extras_require={
         'test': [
-            'codecov==2.1.7',
             'django>=2.2.10,<3.2.15',
             'black==23.1.0',
             'flake8==3.8.4',
             'isort==5.6.4',
-            'pytest-cov==2.8.1',
+            'pytest-cov',
             'pytest-django>=3.8.0,<4.0.0',
             'pytest-sugar>=0.9.2,<1.0.0',
             'pytest==5.3.5',
+            'pytest-codecov',
             'requests>=2.22.0,<3.0.0',
             'requests_mock==1.7.0',
             'setuptools>=45.2.0,<50.0.0',


### PR DESCRIPTION
This PR updates the PR template to no longer mention the changelog as we are no longer mantaining it.

 - [x] Change has a jira ticket that has the correct status.