### PR TITLE
use latest version of directory-client-core and bump django to 4.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [7.2.1](https://pypi.org/project/directory-sso-api-client/7.2.2/)(2023-07-05)
+[Full Changelog](
+
+- KLS-822 - Update directory_client_core  to 7.2.4 and django to 4.2.3
+
 ## [7.2.1](https://pypi.org/project/directory-sso-api-client/7.2.1/)(2023-05-24)
 [Full Changelog](https://github.com/uktrade/directory-sso-api-client/pull/71)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [7.2.1](https://pypi.org/project/directory-sso-api-client/7.2.2/)(2023-07-05)
-[Full Changelog](
+[Full Changelog](https://github.com/uktrade/directory-sso-api-client/pull/72)
 
 - KLS-822 - Update directory_client_core  to 7.2.4 and django to 4.2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [7.2.1](https://pypi.org/project/directory-sso-api-client/7.2.2/)(2023-07-05)
+## [7.2.2](https://pypi.org/project/directory-sso-api-client/7.2.2/)(2023-07-05)
 [Full Changelog](https://github.com/uktrade/directory-sso-api-client/pull/72)
 
 - KLS-822 - Update directory_client_core  to 7.2.4 and django to 4.2.3

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_sso_api_client',
-    version='7.2.1',
+    version='7.2.2',
     url='https://github.com/uktrade/directory-sso-api-client',
     license='MIT',
     author='Department for International Trade',
@@ -12,11 +12,11 @@ setup(
     long_description_content_type='text/markdown',
     include_package_data=True,
     install_requires=[
-        'directory_client_core>=6.2.0,<=7.2.2',
+        'directory_client_core>=7.2.4,<=8.0.0',
     ],
     extras_require={
         'test': [
-            'django>=2.2.10,<=4.2',
+            'django>=2.2.10,<=4.2.3',
             'black==23.1.0',
             'flake8==3.8.4',
             'isort==5.6.4',


### PR DESCRIPTION
use latest version of directory-client-core 7.2.4 and bump django to 4.2.3

 - [x] Change has a jira ticket that has the correct status.
 - [x] A clear description/pull request message has been added.
