### PR TITLE
use directory-client-core 7.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [7.2.3](https://pypi.org/project/directory-sso-api-client/7.2.3/)(2023-07-06)
+[Full Changelog](https://github.com/uktrade/directory-sso-api-client/pull/73)
+
+- KLS-822 - Update directory_client_core  to 7.2.5
+
 ## [7.2.2](https://pypi.org/project/directory-sso-api-client/7.2.2/)(2023-07-05)
 [Full Changelog](https://github.com/uktrade/directory-sso-api-client/pull/72)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_sso_api_client',
-    version='7.2.2',
+    version='7.2.3',
     url='https://github.com/uktrade/directory-sso-api-client',
     license='MIT',
     author='Department for International Trade',
@@ -12,7 +12,7 @@ setup(
     long_description_content_type='text/markdown',
     include_package_data=True,
     install_requires=[
-        'directory_client_core>=7.2.4,<=8.0.0',
+        'directory_client_core>=7.2.5,<=8.0.0',
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
Use at least version 7.2.5 of directory-client-core

 - [x] Change has a jira ticket that has the correct status.
 - [x] A clear description/pull request message has been added.

