### PR TITLE
Feature bgsai 932 add bulk user details endpoint

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,13 +11,13 @@
 #
 name: "CodeQL Advanced"
 
-on:
-  push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
-  schedule:
-    - cron: '32 21 * * 2'
+#on:
+#  push:
+#    branches: [ "master" ]
+#  pull_request:
+#    branches: [ "master" ]
+#  schedule:
+#    - cron: '32 21 * * 2'
 
 jobs:
   analyze:

--- a/directory_sso_api_client/user.py
+++ b/directory_sso_api_client/user.py
@@ -30,6 +30,7 @@ class UserAPIClient(AbstractAPIClient):
         'regenerate_account_verification_code': 'api/v2/verification-code/regenerate/',
         'verify_account_verification_code': 'api/v2/verification-code/verify/',
         'get_account_user': 'api/v2/account-user/',
+        'get_bulk_account_user': 'api/v2/account-user/bulk/',
         'reset_password_invitation': 'api/v2/accounts/password/reset/',
         'reset_password_change': 'api/v2/accounts/password/reset/change/',
         'check_token': 'api/v2/accounts/password/reset/validate/token/',
@@ -266,6 +267,11 @@ class UserAPIClient(AbstractAPIClient):
     def get_account_user(self, hashed_uuid, authenticator=None):
         url = self.endpoints['get_account_user']
         return self.get(url, {'hashed_uuid': hashed_uuid}, authenticator=authenticator)
+
+    @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, max=10))
+    def bulk_get_account_user(self, hashed_uuids, authenticator=None):
+        url = self.endpoints['get_bulk_account_user']
+        return self.get(url, {'hashed_uuids': ','.join(hashed_uuids)}, authenticator=authenticator)
 
     @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, max=10))
     def send_password_reset_email(self, data, authenticator=None):

--- a/directory_sso_api_client/user.py
+++ b/directory_sso_api_client/user.py
@@ -269,7 +269,7 @@ class UserAPIClient(AbstractAPIClient):
         return self.get(url, {'hashed_uuid': hashed_uuid}, authenticator=authenticator)
 
     @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, max=10))
-    def bulk_get_account_user(self, hashed_uuids, authenticator=None):
+    def get_bulk_account_user(self, hashed_uuids, authenticator=None):
         url = self.endpoints['get_bulk_account_user']
         return self.get(url, {'hashed_uuids': ','.join(hashed_uuids)}, authenticator=authenticator)
 


### PR DESCRIPTION
Add a get_bulk_account_user endpoint, which can be used in bg-profile if we have a large number of bg_auth_ids which we need to get additional details for. Links up with: https://github.com/uktrade/directory-sso/pull/1063 and https://github.com/uktrade/bg-profile/pull/84

 - [x] Change has a jira ticket that has the correct status.
 - [x] A clear description/pull request message has been added.

