### PR TITLE
Feature bgsai 932 add bulk user details endpoint

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,13 +11,13 @@
 #
 name: "CodeQL Advanced"
 
-on:
-  push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
-  schedule:
-    - cron: '32 21 * * 2'
+#on:
+#  push:
+#    branches: [ "master" ]
+#  pull_request:
+#    branches: [ "master" ]
+#  schedule:
+#    - cron: '32 21 * * 2'
 
 jobs:
   analyze:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [8.0.1](https://pypi.org/project/directory-sso-api-client/8.0.1/)(2026-05-18)
+[Full Changelog](https://github.com/uktrade/directory-sso-api-client/pull/103)
+- Add get_bulk_account_user endpoint to receieve emails using profile bg_auth_id
+
 ## [8.0.0](https://pypi.org/project/directory-sso-api-client/8.0.0/)(2026-04-17)
 [Full Changelog](https://github.com/uktrade/directory-sso-api-client/pull/101)
 - Bump django to 5.2 lts

--- a/directory_sso_api_client/user.py
+++ b/directory_sso_api_client/user.py
@@ -30,6 +30,7 @@ class UserAPIClient(AbstractAPIClient):
         'regenerate_account_verification_code': 'api/v2/verification-code/regenerate/',
         'verify_account_verification_code': 'api/v2/verification-code/verify/',
         'get_account_user': 'api/v2/account-user/',
+        'get_bulk_account_user': 'api/v2/account-user/bulk/',
         'reset_password_invitation': 'api/v2/accounts/password/reset/',
         'reset_password_change': 'api/v2/accounts/password/reset/change/',
         'check_token': 'api/v2/accounts/password/reset/validate/token/',
@@ -266,6 +267,11 @@ class UserAPIClient(AbstractAPIClient):
     def get_account_user(self, hashed_uuid, authenticator=None):
         url = self.endpoints['get_account_user']
         return self.get(url, {'hashed_uuid': hashed_uuid}, authenticator=authenticator)
+
+    @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, max=10))
+    def bulk_get_account_user(self, hashed_uuids, authenticator=None):
+        url = self.endpoints['get_bulk_account_user']
+        return self.get(url, {'hashed_uuids': ','.join(hashed_uuids)}, authenticator=authenticator)
 
     @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, max=10))
     def send_password_reset_email(self, data, authenticator=None):

--- a/directory_sso_api_client/user.py
+++ b/directory_sso_api_client/user.py
@@ -269,7 +269,7 @@ class UserAPIClient(AbstractAPIClient):
         return self.get(url, {'hashed_uuid': hashed_uuid}, authenticator=authenticator)
 
     @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, max=10))
-    def bulk_get_account_user(self, hashed_uuids, authenticator=None):
+    def get_bulk_account_user(self, hashed_uuids, authenticator=None):
         url = self.endpoints['get_bulk_account_user']
         return self.get(url, {'hashed_uuids': ','.join(hashed_uuids)}, authenticator=authenticator)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_sso_api_client',
-    version='8.0.0',
+    version='8.0.1',
     url='https://github.com/uktrade/directory-sso-api-client',
     license='MIT',
     author='Department for Business and Trade',

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -626,12 +626,13 @@ class UserAPIClientTest(TestCase):
     @mock.patch('directory_client_core.base.AbstractAPIClient.request')
     def test_bulk_get_user_account(self, mocked_request, mocked_authenticator):
         params = {'hashed_uuids': ['blahblah1', 'blahblah2']}
+        qs_params = {'hashed_uuids': 'blahblah1,blahblah2'}
 
         self.client.get_bulk_account_user(**params)
         assert mocked_request.call_count == 1
         assert mocked_request.call_args == mock.call(
             method='GET',
-            params=params,
+            params=qs_params,
             url='api/v2/account-user/bulk/',
             cache_control=None,
             authenticator=None,

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -624,6 +624,21 @@ class UserAPIClientTest(TestCase):
 
     @mock.patch('directory_client_core.authentication.SessionSSOAuthenticator')
     @mock.patch('directory_client_core.base.AbstractAPIClient.request')
+    def test_bulk_get_user_account(self, mocked_request, mocked_authenticator):
+        params = {'hashed_uuids': ['blahblah1', 'blahblah2']}
+
+        self.client.get_bulk_account_user(**params)
+        assert mocked_request.call_count == 1
+        assert mocked_request.call_args == mock.call(
+            method='GET',
+            params=params,
+            url='api/v2/account-user/bulk/',
+            cache_control=None,
+            authenticator=None,
+        )
+
+    @mock.patch('directory_client_core.authentication.SessionSSOAuthenticator')
+    @mock.patch('directory_client_core.base.AbstractAPIClient.request')
     def test_send_password_reset_email(self, mocked_request, mocked_authenticator):
         self.client.send_password_reset_email(
             'test@example.com',


### PR DESCRIPTION
New PR as I've commented out codeQL trigger

Add a get_bulk_account_user endpoint, which can be used in bg-profile if we have a large number of bg_auth_ids which we need to get additional details for. Links up with: https://github.com/uktrade/directory-sso/pull/1063 and https://github.com/uktrade/bg-profile/pull/84



 - [x] Change has a jira ticket that has the correct status.
 - [x] A clear description/pull request message has been added.

