### PR TITLE
log session not found at info level

### DIFF
--- a/directory_sso_api_client/backends.py
+++ b/directory_sso_api_client/backends.py
@@ -29,7 +29,7 @@ class SSOUserBackend:
             response = sso_api_client.user.get_session_user(session_id)
             response.raise_for_status()
         except RequestException as exc:
-            if (exc.response is not None and exc.response.status_code == HTTPStatus.NOT_FOUND):
+            if exc.response is not None and exc.response.status_code == HTTPStatus.NOT_FOUND:
                 logger.info(self.MESSAGE_SESSION_NOT_FOUND, exc_info=True)
             else:
                 logger.error(self.MESSAGE_NOT_SUCCESSFUL, exc_info=True)

--- a/directory_sso_api_client/backends.py
+++ b/directory_sso_api_client/backends.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from http import HTTPStatus
 
 from django.conf import settings
 from django.contrib import auth
@@ -16,6 +17,7 @@ class SSOUserBackend:
         'redirected to http://sorry.great.gov.uk (see ED-2114)'
     )
     MESSAGE_NOT_SUCCESSFUL = 'SSO did not return a 200 response'
+    MESSAGE_SESSION_NOT_FOUND = 'SSO returned a 404 response (session not found)'
 
     def authenticate(self, request):
         session_id = request.COOKIES.get(settings.SSO_SESSION_COOKIE)
@@ -26,8 +28,11 @@ class SSOUserBackend:
         try:
             response = sso_api_client.user.get_session_user(session_id)
             response.raise_for_status()
-        except RequestException:
-            logger.error(self.MESSAGE_NOT_SUCCESSFUL, exc_info=True)
+        except RequestException as exc:
+            if (exc.response is not None and exc.response.status_code == HTTPStatus.NOT_FOUND):
+                logger.info(self.MESSAGE_SESSION_NOT_FOUND, exc_info=True)
+            else:
+                logger.error(self.MESSAGE_NOT_SUCCESSFUL, exc_info=True)
         except json.JSONDecodeError:
             raise ValueError(self.MESSAGE_INVALID_JSON)
         else:

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,10 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_sso_api_client',
-    version='8.0.4',
+    version='8.0.5',
     url='https://github.com/uktrade/directory-sso-api-client',
     license='MIT',
-    author='Department for Business and Trade',
+    author='Department for Business, Innovation, Science and Trade',
     description='Python API client for Export Directory.',
     packages=find_packages(exclude=["tests.*", "tests"]),
     long_description=open('README.md').read(),


### PR DESCRIPTION
Session not found is a common response from directory-sso where a session has expired, i.e. the user needs to log in again. These are currently being logged as errors and polluting DataDog logs (c. 9k in a week). This change reduces the log severity to info level for a 404 response.

To do (delete all that do not apply):

 - [ ] Change has a jira ticket that has the correct status.
 - [ ] A clear description/pull request message has been added.
 - [ ] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
 - [ ] (if updating requirements) Requirements have been compiled.
 - [ ] (if adding env vars) Added any new environment variable to vault.
 - [ ] (if adding feature flags) Cleaned up old flags
